### PR TITLE
change reply from status to value for ref search

### DIFF
--- a/TMCL/motor.py
+++ b/TMCL/motor.py
@@ -84,7 +84,7 @@ class Motor(object):
 
 	def reference_search( self, rfs_type ):
 		reply = self.send(Command.RFS, rfs_type, self.motor_id, 99)
-		return reply.status
+		return reply.value
 
 
 class AxisParameterInterface(object):


### PR DESCRIPTION
The RFS command is designed to be used for 1) initiating reference searches, 2) stopping in progress reference searches, and 3) querying if a reference search is currently in progress. In order for 3) to work, the value of the reply needs to be returned to the caller.